### PR TITLE
feat: 모임원 ROLE 변경 및 모임 권한 변경 및 가입신청 수정

### DIFF
--- a/src/main/java/site/mymeetup/meetupserver/board/service/BoardServiceImpl.java
+++ b/src/main/java/site/mymeetup/meetupserver/board/service/BoardServiceImpl.java
@@ -185,7 +185,7 @@ public class BoardServiceImpl implements BoardService {
         if (!board.getCrew().getCrewId().equals(crewId)) {
             throw new CustomException(ErrorCode.BOARD_CREW_ACCESS_DENIED);
         }
-        if (crewMember.getRole() == CrewMemberRole.EXPELLED || crewMember.getRole() == CrewMemberRole.PENDING || crewMember.getRole() == CrewMemberRole.REJECTED) {
+        if (crewMember.getRole() == CrewMemberRole.EXPELLED || crewMember.getRole() == CrewMemberRole.PENDING || crewMember.getRole() == CrewMemberRole.DEPARTED) {
             throw new CustomException(ErrorCode.CREW_MEMBER_NOT_FOUND);
         }
 
@@ -213,7 +213,7 @@ public class BoardServiceImpl implements BoardService {
         if (!board.getCrew().getCrewId().equals(crewId)) {
             throw new CustomException(ErrorCode.BOARD_CREW_ACCESS_DENIED);
         }
-        if (crewMember.getRole() == CrewMemberRole.EXPELLED || crewMember.getRole() == CrewMemberRole.PENDING || crewMember.getRole() == CrewMemberRole.REJECTED) {
+        if (crewMember.getRole() == CrewMemberRole.EXPELLED || crewMember.getRole() == CrewMemberRole.PENDING || crewMember.getRole() == CrewMemberRole.DEPARTED) {
             throw new CustomException(ErrorCode.CREW_MEMBER_NOT_FOUND);
         }
         if (!comment.getCrewMember().getCrewMemberId().equals(commentSaveReqDto.getCrewMemberId())) {

--- a/src/main/java/site/mymeetup/meetupserver/crew/repository/CrewMemberRepository.java
+++ b/src/main/java/site/mymeetup/meetupserver/crew/repository/CrewMemberRepository.java
@@ -11,13 +11,17 @@ import java.util.Optional;
 
 public interface CrewMemberRepository extends JpaRepository<CrewMember, Long> {
 
+    CrewMember findByCrewAndMember(Crew crew, Member member);
+
     Optional<CrewMember> findByCrew_CrewIdAndMember_MemberId(Long crewId, Long memberId);
 
     List<CrewMember> findByCrew_CrewIdAndRoleInOrderByRoleDesc(Long crewId, List<CrewMemberRole> roles);
 
     List<CrewMember> findByCrew_CrewIdAndRole(Long crewId, CrewMemberRole role);
 
-    boolean existsByCrewAndMember(Crew crew, Member member);
+    boolean existsByCrewAndMemberAndRoleNot(Crew crew, Member member, CrewMemberRole role);
 
     boolean existsByCrewAndMemberAndRole(Crew crew, Member member, CrewMemberRole role);
+
+    Optional<CrewMember> findByCrewAndMemberAndRoleIn(Crew crew, Member member, List<CrewMemberRole> roles);
 }

--- a/src/main/java/site/mymeetup/meetupserver/crew/role/CrewMemberRole.java
+++ b/src/main/java/site/mymeetup/meetupserver/crew/role/CrewMemberRole.java
@@ -11,7 +11,7 @@ public enum CrewMemberRole {
     ADMIN(2, "운영진"),
     LEADER(3, "모임장"),
     PENDING(4, "승인대기"),
-    REJECTED(5, "승인거절");
+    DEPARTED(5, "퇴장");
 
     private final int status;
     private final String name;

--- a/src/main/java/site/mymeetup/meetupserver/exception/ErrorCode.java
+++ b/src/main/java/site/mymeetup/meetupserver/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     ALREADY_CREW_MEMBER(HttpStatus.BAD_REQUEST, "CM40001", "이미 모임원 입니다."),
     CREW_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CM40401", "존재하지 않는 모임원입니다."),
     CREW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C40301", "권한이 없습니다."),
+    ALREADY_PENDING(HttpStatus.BAD_REQUEST, "CM40002", "이미 가입 신청을 한 모임입니다."),
 
     // 모임 찜
     ALREADY_CREW_LIKE(HttpStatus.BAD_REQUEST, "CL40001", "이미 찜을 한 모임입니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #43, #69, #109 

## 📝 작업 내용
- 기존 ROLE REJECTED -> DEPARTED(퇴장)으로 변경
- 회원 퇴장 시 DB에서 지우는 것이 아닌 상태값만 변경하기로 결정
- 모임 가입 신청 시에 퇴장한 멤버라면 재신청 가능하도록 변경
- 회원 퇴장도 권한 변경에 병합