### PR TITLE
feat: 작성자 ID 값만 가져오도록 수정

### DIFF
--- a/src/main/java/site/mymeetup/meetupserver/meeting/dto/MeetingDto.java
+++ b/src/main/java/site/mymeetup/meetupserver/meeting/dto/MeetingDto.java
@@ -82,7 +82,7 @@ public class MeetingDto {
         private LocalDateTime createDate;
         private LocalDateTime updateDate;
         private Long crewId;
-        private CrewMember crewMember;
+        private Long crewMemberId;
 
         @Builder
         public MeetingSelectRespDto(Meeting meeting) {
@@ -99,7 +99,7 @@ public class MeetingDto {
             this.createDate = meeting.getCreateDate();
             this.updateDate = meeting.getUpdateDate();
             this.crewId = meeting.getCrew().getCrewId();
-            this.crewMember = meeting.getCrewMember();
+            this.crewMemberId = meeting.getCrewMember().getCrewMemberId();
         }
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #121 

## 📝 작업 내용
조회 시 모임 작성자의 ID 값만 가져오도록 코드 수정
