### PR TITLE
feat: 사진첩 권한 확인

### DIFF
--- a/src/main/java/site/mymeetup/meetupserver/album/control/AlbumController.java
+++ b/src/main/java/site/mymeetup/meetupserver/album/control/AlbumController.java
@@ -2,12 +2,14 @@ package site.mymeetup.meetupserver.album.control;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import static site.mymeetup.meetupserver.album.dto.AlbumDto.AlbumRespDto;
+import static site.mymeetup.meetupserver.album.dto.AlbumDto.AlbumSelectRespDto;
 import static site.mymeetup.meetupserver.album.dto.AlbumDto.AlbumSaveRespDto;
 import org.springframework.web.multipart.MultipartFile;
 import static site.mymeetup.meetupserver.album.dto.AlbumLikeRespDto.AlbumLikeSaveRespDto;
 import site.mymeetup.meetupserver.album.service.AlbumService;
+import site.mymeetup.meetupserver.member.dto.CustomUserDetails;
 import site.mymeetup.meetupserver.response.ApiResponse;
 import java.util.List;
 
@@ -21,30 +23,34 @@ public class AlbumController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{crewId}/albums")
     public ApiResponse<List<AlbumSaveRespDto>> createAlbum(@PathVariable Long crewId,
-                                                           @RequestParam List<MultipartFile> images) {
-        return ApiResponse.success(albumService.createAlbum(crewId, images));
+                                                           @RequestParam List<MultipartFile> images,
+                                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.success(albumService.createAlbum(crewId, images, userDetails));
     }
 
     // 사진첩 목록 조회
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{crewId}/albums")
-    public ApiResponse<List<AlbumRespDto>> getAlbumByCrewId (@PathVariable Long crewId) {
+    public ApiResponse<List<AlbumSelectRespDto>> getAlbumByCrewId (@PathVariable Long crewId) {
         return ApiResponse.success(albumService.getAlbumByCrewId(crewId));
     }
 
     // 사진첩 상세 조회
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{crewId}/albums/{albumId}")
-    public ApiResponse<AlbumRespDto> getAlbumByCrewIdAndAlbumId (@PathVariable Long crewId,
-                                                                 @PathVariable Long albumId) {
-        return ApiResponse.success(albumService.getAlbumByCrewIdAndAlbumId(crewId, albumId));
+    public ApiResponse<AlbumSelectRespDto> getAlbumByCrewIdAndAlbumId (@PathVariable Long crewId,
+                                                                 @PathVariable Long albumId,
+                                                                 @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.success(albumService.getAlbumByCrewIdAndAlbumId(crewId, albumId, userDetails));
     }
 
     // 사진첩 삭제
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/{crewId}/albums/{albumId}")
-    public ApiResponse<?> deleteAlbum(@PathVariable Long crewId, @PathVariable Long albumId) {
-        albumService.deleteAlbum(crewId, albumId);
+    public ApiResponse<?> deleteAlbum(@PathVariable Long crewId,
+                                      @PathVariable Long albumId,
+                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
+        albumService.deleteAlbum(crewId, albumId, userDetails);
         return ApiResponse.success(null);
     }
 
@@ -52,15 +58,17 @@ public class AlbumController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{crewId}/albums/{albumId}/likes")
     public ApiResponse<AlbumLikeSaveRespDto> likeAlbum(@PathVariable Long crewId,
-                                                       @PathVariable Long albumId) {
-        return ApiResponse.success(albumService.likeAlbum(crewId, albumId));
+                                                       @PathVariable Long albumId,
+                                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.success(albumService.likeAlbum(crewId, albumId, userDetails));
     }
 
     // 사진첩 좋아요 여부 조회
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{crewId}/albums/{albumId}/likes")
     public ApiResponse<Boolean> isLikeCrew(@PathVariable Long crewId,
-                                           @PathVariable Long albumId) {
-        return ApiResponse.success(albumService.isLikeAlbum(crewId, albumId));
+                                           @PathVariable Long albumId,
+                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.success(albumService.isLikeAlbum(crewId, albumId, userDetails));
     }
 }

--- a/src/main/java/site/mymeetup/meetupserver/album/service/AlbumService.java
+++ b/src/main/java/site/mymeetup/meetupserver/album/service/AlbumService.java
@@ -1,23 +1,25 @@
 package site.mymeetup.meetupserver.album.service;
 
 import org.springframework.web.multipart.MultipartFile;
+import site.mymeetup.meetupserver.member.dto.CustomUserDetails;
+
 import static site.mymeetup.meetupserver.album.dto.AlbumLikeRespDto.AlbumLikeSaveRespDto;
 
-import static site.mymeetup.meetupserver.album.dto.AlbumDto.AlbumRespDto;
+import static site.mymeetup.meetupserver.album.dto.AlbumDto.AlbumSelectRespDto;
 import static site.mymeetup.meetupserver.album.dto.AlbumDto.AlbumSaveRespDto;
 import java.util.List;
 
 public interface AlbumService {
 
-    List<AlbumSaveRespDto> createAlbum(Long crewId, List<MultipartFile> images);
+    List<AlbumSaveRespDto> createAlbum(Long crewId, List<MultipartFile> images, CustomUserDetails userDetails);
 
-    List<AlbumRespDto> getAlbumByCrewId(Long crewId);
+    List<AlbumSelectRespDto> getAlbumByCrewId(Long crewId);
 
-    AlbumRespDto getAlbumByCrewIdAndAlbumId(Long crewId, Long albumId);
+    AlbumSelectRespDto getAlbumByCrewIdAndAlbumId(Long crewId, Long albumId, CustomUserDetails userDetails);
 
-    void deleteAlbum(Long crewId, Long albumId);
+    void deleteAlbum(Long crewId, Long albumId, CustomUserDetails userDetails);
 
-    boolean isLikeAlbum(Long crewId, Long albumId);
+    boolean isLikeAlbum(Long crewId, Long albumId, CustomUserDetails userDetails);
 
-    AlbumLikeSaveRespDto likeAlbum(Long crewId, Long albumId);
+    AlbumLikeSaveRespDto likeAlbum(Long crewId, Long albumId, CustomUserDetails userDetails);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #198 

## 📝 작업 내용
- 사진첩 상세 페이지는 모임에 가입된 경우에만 접근 가능
- 사진첩 좋아요는 모임에 가입된 경우에만 가능
- 로그인한 유저와 작성자가 동일한 경우 사진첩 삭제 가능
- 로그인한 유저가 모임장 or 관리자일 경우 사진첩 삭제 가능
- 메서드 리팩토링