### PR TITLE
chore: maxLifetime 조정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,4 +45,7 @@ spring.web.resources.add-mappings=false
 # time-zone setting
 spring.jackson.time-zone=Asia/Seoul
 
+# 450s (7m 30s)
+spring.datasource.hikari.maxLifetime=450000
+
 spring.jpa.open-in-view=false


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #272 

## 📝 작업 내용
- HikariCP의 maxLifetime 값이 MySQL 서버에서 허용하는 시간보다 길어서 연결이 닫히는 문제 해결